### PR TITLE
placeholder image fix

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -4,6 +4,8 @@ import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
 
+const placeholderImage = "/placeholder.png"
+
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
     dispatch({
@@ -37,7 +39,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || placeholderImage}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
#INC-5312: Missing image #2 

When creating a new product without an image, there are broken images showing up in the product catalogue.

I have fixed the issue.

![Screenshot 2023-05-02 031834](https://user-images.githubusercontent.com/28870324/235565786-f606fe77-34e8-4258-9657-1586e33102e2.png)
